### PR TITLE
Add stubbed tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+CC=gcc
+CFLAGS=-I_01ConsoleRun -Itests -DTESTING -std=c99
+
+TEST_SRC=tests/test_main.c _01ConsoleRun/main.c
+TEST_BIN=tests/test_main
+
+all:
+	$(CC) $(CFLAGS) $(TEST_SRC) -o $(TEST_BIN)
+
+.PHONY: clean test
+clean:
+	rm -f $(TEST_BIN)
+
+test: all
+	./$(TEST_BIN)

--- a/_01ConsoleRun/header.h
+++ b/_01ConsoleRun/header.h
@@ -4,7 +4,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <conio.h>
+#ifdef _WIN32
 #include <Windows.h>
+#else
+#include "win_stub.h"
+#endif
 #include <time.h>
 
 
@@ -30,8 +34,13 @@
 #define KEY_ENT 13
 
 
+#ifdef DEFINE_GLOBALS
 short restarted = 1;
 short paused = 0;
+#else
+extern short restarted;
+extern short paused;
+#endif
 
 typedef enum _MAN_STATE {
     STOOPING = -1,

--- a/_01ConsoleRun/main.c
+++ b/_01ConsoleRun/main.c
@@ -1,6 +1,8 @@
+#define DEFINE_GLOBALS
 #include "header.h"
 
 
+#ifndef TESTING
 int main(void) {
     HANDLE hStdout = GetStdHandle(STD_OUTPUT_HANDLE);
     HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
@@ -138,6 +140,7 @@ int main(void) {
     }
     return 0;
 }
+#endif /* TESTING */
 
 
 void drawRoute(INT yFloor) {

--- a/tests/conio.h
+++ b/tests/conio.h
@@ -1,0 +1,5 @@
+#ifndef CONIO_STUB_H
+#define CONIO_STUB_H
+static inline int _kbhit(void) { return 0; }
+static inline int _getch(void) { return 0; }
+#endif

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1,0 +1,30 @@
+#include "header.h"
+#include <assert.h>
+
+int main(void) {
+    MPOS man = drawStandingMan(1, 1);
+    drawRoute(ROUTE_LINE);
+    printScore(man);
+    paused = 0;
+    pauseGame();
+    man.isDead = 1;
+    checkIfDead(&man);
+    man = drawRunningMan(2, 2);
+    drawJumpingMan(2, 3);
+    man = moveForward(&man, 0);
+    man.isDead = 1;
+    runEffect(&man);
+    testBody(&man);
+    jump(&man);
+    stoop(&man, VK_DOWN);
+    shootBullets(&man);
+
+    BLIST list = {NULL, NULL};
+    BPOS bullet = {NULL, 5, 5};
+    insertTail(&list, &bullet);
+    assert(list.pHead == &bullet && list.pTail == &bullet);
+    removeHead(&list);
+    assert(list.pHead == NULL && list.pTail == NULL);
+
+    return 0;
+}

--- a/tests/win_stub.h
+++ b/tests/win_stub.h
@@ -1,0 +1,47 @@
+#ifndef WIN_STUB_H
+#define WIN_STUB_H
+#include <stdint.h>
+#include <unistd.h>
+
+typedef int BOOL;
+typedef unsigned char BYTE;
+typedef unsigned int UINT;
+typedef int INT;
+typedef struct { short X; short Y; } COORD;
+typedef struct { COORD dwSize; } CONSOLE_SCREEN_BUFFER_INFO;
+typedef struct { unsigned long cbSize; short nFont; COORD dwFontSize; int FontFamily; int FontWeight; wchar_t FaceName[32]; } CONSOLE_FONT_INFOEX;
+typedef struct { unsigned long dwSize; BOOL bVisible; } CONSOLE_CURSOR_INFO;
+typedef struct { short Left; short Top; short Right; short Bottom; } SMALL_RECT;
+typedef void* HANDLE;
+typedef void* HWND;
+
+#define STD_INPUT_HANDLE 0
+#define STD_OUTPUT_HANDLE 1
+
+static inline HANDLE GetStdHandle(int x) { return (HANDLE)0; }
+static inline HWND GetConsoleWindow(void) { return (HWND)0; }
+static inline int GetCurrentConsoleFontEx(HANDLE h, BOOL b, CONSOLE_FONT_INFOEX *c) { return 0; }
+static inline int SetCurrentConsoleFontEx(HANDLE h, BOOL b, CONSOLE_FONT_INFOEX *c) { return 0; }
+static inline int SetConsoleCursorInfo(HANDLE h, const CONSOLE_CURSOR_INFO *c) { return 0; }
+static inline int SetConsoleScreenBufferSize(HANDLE h, COORD c) { return 0; }
+static inline int SetConsoleWindowInfo(HANDLE h, int abs, const SMALL_RECT *r) { return 0; }
+static inline long SetWindowLong(HWND hwnd, int idx, long newLong) { return 0; }
+static inline long GetWindowLong(HWND hwnd, int idx) { return 0; }
+static inline void* GetSystemMenu(HWND hwnd, int b) { return 0; }
+static inline int DeleteMenu(void* menu, int pos, int flags) { return 0; }
+static inline int ShowScrollBar(HWND hwnd, int bar, BOOL show) { return 0; }
+static inline int SetConsoleMode(HANDLE h, int mode) { return 0; }
+static inline int SetConsoleTitleW(const wchar_t* title) { return 0; }
+static inline void FlushConsoleInputBuffer(HANDLE h) { (void)h; }
+static inline short GetKeyState(int key) { return 0; }
+
+#define VK_DOWN 0
+#define GWL_STYLE 0
+#define WS_SIZEBOX 0
+#define SC_MAXIMIZE 0
+#define MF_BYCOMMAND 0
+#define SB_BOTH 0
+
+static inline void Sleep(int ms) { usleep(ms * 1000); }
+
+#endif /* WIN_STUB_H */


### PR DESCRIPTION
## Summary
- add Makefile for test build
- stub Windows-specific functions for non-Windows test runs
- expose globals via `DEFINE_GLOBALS` switch
- disable main when testing
- provide basic test harness exercising game functions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683fcd2355588327980ff835d67f2d0e